### PR TITLE
Support Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "crypto-random-string": "^3.3.1",
     "express": "^4.17.1",
     "fs-extra": "^9.1.0",
-    "mailparser": "^3.1.0",
-    "smtp-server": "^3.8.0",
+    "mailparser": "^3.5.0",
+    "smtp-server": "^3.11.0",
     "tagged-template-noop": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Was running into errors running the test on Node 18, e.g.:

```
TypeError: Cannot set property closed of #<Writable> which has only a getter
    at new SMTPStream (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-stream.js:34:21)
    at new SMTPConnection (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-connection.js:55:24)
    at SMTPServer.connect (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-server.js:93:26)
    at /Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-server.js:84:26
    at Immediate.<anonymous> (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-server.js:345:39)
    at processImmediate (node:internal/timers:471:21)
```

```
TypeError: Cannot set property errored of [object Object] which has only a getter
    at new MessageSplitter (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/mailsplit/lib/message-splitter.js:28:22)
    at new MailParser (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/mailparser/lib/mail-parser.js:132:25)
    at Object.<anonymous>.module.exports [as simpleParser] (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/mailparser/lib/simple-parser.js:29:18)
    at SMTPServer.onData (/Users/themaxdavitt/Projects/kill-the-newsletter/source/index.ts:437:40)
    at SMTPConnection.handler_DATA (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-connection.js:1307:22)
    at SMTPConnection._onCommand (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-connection.js:497:17)
    at SMTPStream.SMTPConnection._parser.oncommand (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-connection.js:58:52)
    at readLine (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-stream.js:128:22)
    at SMTPStream._write (/Users/themaxdavitt/Projects/kill-the-newsletter/node_modules/smtp-server/lib/smtp-stream.js:132:13)
    at writeOrBuffer (node:internal/streams/writable:392:12)
```

Turns out that it added some properties to [`stream.Writable`](https://nodejs.org/api/stream.html#writableclosed) and [`stream.Readable`](https://nodejs.org/api/stream.html#readableerrored) that overlapped with property names in derived classes in two dependencies: [`smtp-server`](https://github.com/nodemailer/smtp-server/commit/2bd0975292208f1cf77d7a93cb3d8b3c4d48acb8) and [`mailparser`](https://github.com/nodemailer/mailparser/commit/88c26ca389f7f6f0ccafac14f971ee37f7eff1d6). After updating those dependencies to versions that include the (linked) commits fixing the issues, which also happen to be the latest versions of them, the test now works for me.