### PR TITLE
pin dependency-version to pre-ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@leafac/css": "^0.0.1",
-        "@leafac/html": "^3.0.0",
+        "@leafac/html": "3.0.0",
         "@leafac/sqlite": "^1.1.2",
         "@leafac/sqlite-migration": "^1.0.3",
         "@small-tech/auto-encrypt": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@leafac/css": "^0.0.1",
-    "@leafac/html": "^3.0.0",
+    "@leafac/html": "3.0.0",
     "@leafac/sqlite": "^1.1.2",
     "@leafac/sqlite-migration": "^1.0.3",
     "@small-tech/auto-encrypt": "^2.0.5",


### PR DESCRIPTION
I would get this error message when running `kill-the-newsletter` after building it myself:

```
node:internal/modules/cjs/loader:1041
    throw new ERR_REQUIRE_ESM(filename, true);
    ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /tmp/caxa/kill-the-newsletter/2srbcxrtto/node_modules/@leafac/html/build/index.mjs not supported.
Instead change the require of /tmp/caxa/kill-the-newsletter/2srbcxrtto/node_modules/@leafac/html/build/index.mjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/tmp/caxa/kill-the-newsletter/2srbcxrtto/distribution/index.js:13:16) {
  code: 'ERR_REQUIRE_ESM'
```

Since caxa ignores the package-lock.json, version 3.0.3 of leafac/html is installed, which already is migrated to use ESM imports; with this PR I require the old version of the dependency that can be imported normally.