### PR TITLE
Support optionally including the sender in the feed entry title

### DIFF
--- a/source/index.mts
+++ b/source/index.mts
@@ -1681,6 +1681,12 @@ if (application.commandLineArguments.values.type === "email") {
                 where "id" = ${feed.id};
               `,
             );
+            const entrySender = feed.params.includes("showsender")
+              ? email.from?.value[0].name || email.from?.value[0].address
+              : null;
+            const entryTitle =
+              (entrySender ? entrySender + ": " : "") +
+              (email.subject ?? "Untitled");
             const feedEntry = application.database.get<{
               id: number;
               publicId: string;
@@ -1705,7 +1711,7 @@ if (application.commandLineArguments.values.type === "email") {
                         ${feed.id},
                         ${new Date().toISOString()},
                         ${(session.envelope.mailFrom as SMTPServerAddress).address},
-                        ${email.subject ?? "Untitled"},
+                        ${entryTitle},
                         ${typeof email.html === "string" ? email.html : typeof email.textAsHtml === "string" ? email.textAsHtml : "No content."}
                       );
                     `,
@@ -1795,6 +1801,7 @@ if (application.commandLineArguments.values.type === "email") {
               session.envelope.mailFrom === false
                 ? ""
                 : session.envelope.mailFrom.address,
+              entryTitle,
               "DELETED ENTRIES",
               JSON.stringify(
                 deletedFeedEntries.map(

--- a/source/index.mts
+++ b/source/index.mts
@@ -1598,17 +1598,20 @@ if (application.commandLineArguments.values.type === "email") {
             address.match(utilities.emailRegExp) === null
           )
             return [];
-          const [feedPublicId, hostname] = address.split("@");
+          const [feedAddress, hostname] = address.split("@");
+          const [feedPublicId, ...feedParams] = feedAddress.split("+");
           if (hostname !== application.configuration.hostname) return [];
           const feed = application.database.get<{
             id: number;
             publicId: string;
+            params: string[];
           }>(
             sql`
               select "id", "publicId" from "feeds" where "publicId" = ${feedPublicId};
             `,
           );
           if (feed === undefined) return [];
+          feed.params = feedParams;
           return [feed];
         });
         if (feeds.length === 0) throw new Error("No valid recipients.");

--- a/source/index.test.mts
+++ b/source/index.test.mts
@@ -1,17 +1,53 @@
 import path from "node:path";
 import nodemailer from "nodemailer";
 
-await nodemailer
-  .createTransport({
-    host: "localhost",
-    port: 25,
-  })
-  .sendMail({
-    from: `"Example of Sender" <sender@example.com>`,
-    to: `"Example of Recipient" <r5bsqg3w6gqrsv7m59f1@localhost>`,
-    subject: "Example of a Newsletter Entry",
-    html: "<p>Hello <strong>World</strong></p>".repeat(2 ** 0 /* 13 */),
-    attachments: [
-      { path: path.join(import.meta.dirname, "../static/favicon.ico") },
-    ],
-  });
+const transporter = nodemailer.createTransport({
+  host: "localhost",
+  port: 25,
+  secure: false,
+  tls: { rejectUnauthorized: false },
+});
+
+// Base case
+await transporter.sendMail({
+  from: `"Example of Sender" <sender@example.com>`,
+  to: `"Example of Recipient" <r5bsqg3w6gqrsv7m59f1@localhost>`,
+  subject: "Example of a Newsletter Entry",
+  html: "<p>Hello <strong>World</strong></p>".repeat(2 ** 0 /* 13 */),
+  attachments: [
+    { path: path.join(import.meta.dirname, "../static/favicon.ico") },
+  ],
+});
+
+// Param: showsender (has display name)
+await transporter.sendMail({
+  from: `"Example of Sender" <sender@example.com>`,
+  to: `"Example of Recipient" <r5bsqg3w6gqrsv7m59f1+showsender@localhost>`,
+  subject: "Example of a Newsletter Entry",
+  html: "<p>Hello <strong>World</strong></p>".repeat(2 ** 0 /* 13 */),
+  attachments: [
+    { path: path.join(import.meta.dirname, "../static/favicon.ico") },
+  ],
+});
+
+// Param: showsender (addr-spec only)
+await transporter.sendMail({
+  from: `sender@example.com`,
+  to: `"Example of Recipient" <r5bsqg3w6gqrsv7m59f1+showsender@localhost>`,
+  subject: "Example of a Newsletter Entry",
+  html: "<p>Hello <strong>World</strong></p>".repeat(2 ** 0 /* 13 */),
+  attachments: [
+    { path: path.join(import.meta.dirname, "../static/favicon.ico") },
+  ],
+});
+
+// Param: <undefined>
+await transporter.sendMail({
+  from: `sender@example.com`,
+  to: `"Example of Recipient" <r5bsqg3w6gqrsv7m59f1+NotARealParam@localhost>`,
+  subject: "Example of a Newsletter Entry",
+  html: "<p>Hello <strong>World</strong></p>".repeat(2 ** 0 /* 13 */),
+  attachments: [
+    { path: path.join(import.meta.dirname, "../static/favicon.ico") },
+  ],
+});


### PR DESCRIPTION
Borrowing a concept from [Read Email Later](https://www.reademaillater.com/), this adds support for passing parameters via plus-addressing and implements a `+showsender` parameter to format feed entry titles like "&lt;sender&gt;: &lt;subject&gt;"